### PR TITLE
chore: queryKey에서 빈 스트링 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-query-key-helper",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "type": "module",
   "main": "dist/bundle.js",
   "module": "dist/bundle.es.js",

--- a/src/createQueryKeyHelper.ts
+++ b/src/createQueryKeyHelper.ts
@@ -1,5 +1,5 @@
-import { QueryKey } from "@tanstack/react-query";
-import { isNonNil } from "./utils";
+import { QueryKey } from '@tanstack/react-query';
+import { isNonNil } from './utils';
 
 interface QueryKeyHelperProps<PathVariables, Payload, Response> {
   apiUrl: (pathVariables: PathVariables) => string;
@@ -25,8 +25,10 @@ export const createQueryOption =
       queryFn: () => {
         return props.queryFn(apiUrl, payload);
       },
-      queryKey: [apiUrl.split("/"), payload, pathVariables].filter(
-        isNonNil
-      ) as QueryKey,
+      queryKey: [
+        apiUrl.split('/').filter((value) => value !== ''),
+        payload,
+        pathVariables,
+      ].filter(isNonNil) as QueryKey,
     };
   };


### PR DESCRIPTION
"/path" URL에서 `split('/')`을 하면 빈 스트링이 배열 맨 앞에 추가된다.
  - `['', 'path']`
  
빈 스트링을 제거하기 위해 `slice(1)` 추가

`filter()`로 빈 문자열을 제거해주는게 좋을지 `slice()`를 쓰는게 좋을지...